### PR TITLE
Update for usage with gulp-mainbowerfiles and the like

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bitter-fontface",
   "version": "0.1.3",
-  "main": "./fonts/**/*.{woff,svg,eot,ttf}"
+  "main": "./fonts/**/*.{woff,svg,eot,ttf}",
   "homepage": "https://github.com/FontFaceKit/bitter",
   "authors": [
     "Stefan Maric <me@stefanmaric.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bitter-fontface",
   "version": "0.1.3",
-  "main": "./**/**/*.{woff,svg,eot,ttf,css}",
+  "main": "./**/*.{woff,svg,eot,ttf,css}",
   "homepage": "https://github.com/FontFaceKit/bitter",
   "authors": [
     "Stefan Maric <me@stefanmaric.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bitter-fontface",
   "version": "0.1.3",
-  "main": "./fonts/**/*.{woff,svg,eot,ttf,css}",
+  "main": "./**/**/*.{woff,svg,eot,ttf,css}",
   "homepage": "https://github.com/FontFaceKit/bitter",
   "authors": [
     "Stefan Maric <me@stefanmaric.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bitter-fontface",
   "version": "0.1.3",
-  "main": "./bitter.css",
+  "main": "./fonts/**/*.{woff,svg,eot,ttf}"
   "homepage": "https://github.com/FontFaceKit/bitter",
   "authors": [
     "Stefan Maric <me@stefanmaric.com>"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "bitter-fontface",
   "version": "0.1.3",
-  "main": "./fonts/**/*.{woff,svg,eot,ttf}",
+  "main": "./fonts/**/*.{woff,svg,eot,ttf,css}",
   "homepage": "https://github.com/FontFaceKit/bitter",
   "authors": [
     "Stefan Maric <me@stefanmaric.com>"


### PR DESCRIPTION
Basically as things stand, importing ./bitter.css does very little for those of using things like gulp and grunt with bower because the final destination of the assets might be somewhere other than the bower directory where ./bitter.css has no actual meaning. Therefore it's nice to be able to just use the fonts directly :)
